### PR TITLE
`--ssh-user` arg should override `knife[:ssh_user]`

### DIFF
--- a/lib/chef/knife/zero_bootstrap.rb
+++ b/lib/chef/knife/zero_bootstrap.rb
@@ -138,14 +138,14 @@ class Chef
         ssh.ui = ui
         ssh.name_args = [ server_name, ssh_command ]
         ssh.config = Net::SSH.configuration_for(server_name)
-        ssh.config[:ssh_user] = Chef::Config[:knife][:ssh_user] || config[:ssh_user]
+        ssh.config[:ssh_user] = config[:ssh_user] || Chef::Config[:knife][:ssh_user]
         ssh.config[:ssh_password] = config[:ssh_password]
-        ssh.config[:ssh_port] = Chef::Config[:knife][:ssh_port] || config[:ssh_port]
-        ssh.config[:ssh_gateway] = Chef::Config[:knife][:ssh_gateway] || config[:ssh_gateway]
-        ssh.config[:forward_agent] = Chef::Config[:knife][:forward_agent] || config[:forward_agent]
-        ssh.config[:identity_file] = Chef::Config[:knife][:identity_file] || config[:identity_file]
+        ssh.config[:ssh_port] = config[:ssh_port] || Chef::Config[:knife][:ssh_port]
+        ssh.config[:ssh_gateway] = config[:ssh_gateway] || Chef::Config[:knife][:ssh_gateway]
+        ssh.config[:forward_agent] = config[:forward_agent] || Chef::Config[:knife][:forward_agent]
+        ssh.config[:identity_file] = config[:identity_file] || Chef::Config[:knife][:identity_file]
         ssh.config[:manual] = true
-        ssh.config[:host_key_verify] = Chef::Config[:knife][:host_key_verify] || config[:host_key_verify]
+        ssh.config[:host_key_verify] = config[:host_key_verify] || Chef::Config[:knife][:host_key_verify]
         ssh.config[:on_error] = :raise
         ssh
         rescue => e


### PR DESCRIPTION
Currently, a setting in `.chef/knife.rb` overrides the command line argument, which doesn't strike me as expected.