### PR TITLE
fix #22 load_config before build remote command.

### DIFF
--- a/lib/chef/knife/zero_chef_client.rb
+++ b/lib/chef/knife/zero_chef_client.rb
@@ -15,8 +15,16 @@ class Chef
       banner "knife zero chef_client QUERY (options) | It's same as converge"
 
       self.options = Ssh.options.merge(self.options)
-      self.options[:use_sudo] = Bootstrap.options[:use_sudo]
       self.options[:use_sudo_password] = Bootstrap.options[:use_sudo_password]
+
+
+      option :use_sudo,
+        :long => "--[no-]sudo",
+        :description => "Execute the chef-client via sudo (true by default)",
+        :boolean => true,
+        :default => true,
+        :proc => lambda { |v| Chef::Config[:knife][:use_sudo] = v }
+
 
       option :override_runlist,
         :short        => "-o RunlistItem,RunlistItem...",
@@ -28,17 +36,19 @@ class Chef
 
       def initialize(argv=[])
         super
+        self.configure_chef
         @name_args = [@name_args[0], start_chef_client]
       end
 
       def start_chef_client
-        client_path = @config[:use_sudo] ? 'sudo ' : ''
+        client_path = @config[:use_sudo] || Chef::Config[:knife][:use_sudo] ? 'sudo ' : ''
         client_path = @config[:chef_client_path] ? "#{client_path}#{@config[:chef_client_path]}" : "#{client_path}chef-client"
         s = "#{client_path}"
         s << ' -l debug' if @config[:verbosity] and @config[:verbosity] >= 2
         s << " -S http://127.0.0.1:#{::Knife::Zero::Helper.zero_remote_port}"
         s << " -o #{@config[:override_runlist]}" if @config[:override_runlist]
         s << " -W" if @config[:why_run]
+        Chef::Log.info "Remote command: " + s
         s
       end
     end


### PR DESCRIPTION
use sudo for converge has two ways.

- pass via cli --sudo/--no-sudo.
- set  `knife[:ssl_verify_mode]` to  knife.rb.

true by default.