### PR TITLE
Feature/customize client.rb for filter attributes.

### DIFF
--- a/lib/chef/knife/zero_base.rb
+++ b/lib/chef/knife/zero_base.rb
@@ -7,7 +7,7 @@ class Chef
         includer.class_eval do
           deps do
             Chef::Config[:local_mode] = true
-            Chef::Config[:knife_zero] = true
+            Chef::Config[:knife_zero] = Hash.new
             Chef::Knife::Ssh.load_deps
           end
 

--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -18,8 +18,13 @@ class Chef
            alias :orig_config_content config_content
            def config_content
              client_rb = orig_config_content
-             if Chef::Config[:knife][:knife_zero][:automatic_attribute_whitelist] && Chef::Config[:knife][:knife_zero][:automatic_attribute_whitelist].is_a?(Array)
-               client_rb << "automatic_attribute_whitelist #{Chef::Config[:knife][:knife_zero][:automatic_attribute_whitelist].to_s}"
+             %w{ automatic_attribute_whitelist default_attribute_whitelist normal_attribute_whitelist override_attribute_whitelist }.each do |white_list|
+               if Chef::Config[:knife][:knife_zero][white_list.to_sym] && Chef::Config[:knife][:knife_zero][white_list.to_sym].is_a?(Array)
+                 client_rb << [
+                   white_list,
+                   Chef::Config[:knife][:knife_zero][white_list.to_sym].to_s
+                 ].join(" ")
+               end
              end
              client_rb
            end

--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -19,10 +19,10 @@ class Chef
            def config_content
              client_rb = orig_config_content
              %w{ automatic_attribute_whitelist default_attribute_whitelist normal_attribute_whitelist override_attribute_whitelist }.each do |white_list|
-               if Chef::Config[:knife][:knife_zero][white_list.to_sym] && Chef::Config[:knife][:knife_zero][white_list.to_sym].is_a?(Array)
+               if Chef::Config[:knife][white_list.to_sym] && Chef::Config[:knife][white_list.to_sym].is_a?(Array)
                  client_rb << [
                    white_list,
-                   Chef::Config[:knife][:knife_zero][white_list.to_sym].to_s
+                   Chef::Config[:knife][white_list.to_sym].to_s
                  ].join(" ")
                end
              end

--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -18,8 +18,8 @@ class Chef
            alias :orig_config_content config_content
            def config_content
              client_rb = orig_config_content
-             if Chef::Config[:knife][:attribute_whitelist] && Chef::Config[:knife][:attribute_whitelist].is_a?(Array)
-               client_rb << "automatic_attribute_whitelist #{Chef::Config[:knife][:attribute_whitelist].to_s}"
+             if Chef::Config[:knife][:knife_zero][:automatic_attribute_whitelist] && Chef::Config[:knife][:knife_zero][:automatic_attribute_whitelist].is_a?(Array)
+               client_rb << "automatic_attribute_whitelist #{Chef::Config[:knife][:knife_zero][:automatic_attribute_whitelist].to_s}"
              end
              client_rb
            end

--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -15,6 +15,15 @@ class Chef
              end
            end
 
+           alias :orig_config_content config_content
+           def config_content
+             client_rb = orig_config_content
+             if Chef::Config[:knife][:attribute_whitelist] && Chef::Config[:knife][:attribute_whitelist].is_a?(Array)
+               client_rb << "automatic_attribute_whitelist #{Chef::Config[:knife][:attribute_whitelist].to_s}"
+             end
+             client_rb
+           end
+
            alias :orig_start_chef start_chef
            def start_chef
              if @chef_config[:knife_zero]

--- a/test/chef/knife/test_zero_bootstrap.rb
+++ b/test/chef/knife/test_zero_bootstrap.rb
@@ -10,7 +10,7 @@ class TC_ZeroBootstrap < Test::Unit::TestCase
     end
 
     test "returns true from Chef::Config[:knife_zero]" do
-      assert_true(Chef::Config[:knife_zero])
+      assert_equal({}, Chef::Config[:knife_zero])
     end
 
     test "returns expected bootstrap template(for notice changes of core to me)" do


### PR DESCRIPTION
from knife.rb

```
knife[: automatic_attribute_whitelist] = [
  "fqdn/",
  "ipaddress/",
  "roles/",
  "recipes/",
  "ipaddress/",
  "platform/",
  "platform_version/",
  "cloud",
  "cloud_v2"
]
```

to client.rb

```
...

automatic_attribute_whitelist ["fqdn/", "ipaddress/", "roles/", "recipes/", "ipaddress/", "platform/", "platform_version/", "cloud", "cloud_v2"]
```


creates

```
{
  "name": "knife-zero02",
  "normal": {
    "tags": [

    ]
  },
  "automatic": {
    "ipaddress": "133.242.xxx.xxx",
    "roles": [

    ],
    "recipes": [

    ],
    "platform": "ubuntu",
    "platform_version": "14.04",
    "cloud_v2": null
  }
```