### PR TITLE
knife zero bootstrap can't include more than 2 white lists

### DIFF
--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -18,15 +18,16 @@ class Chef
            alias :orig_config_content config_content
            def config_content
              client_rb = orig_config_content
+             white_lists = []
              %w{ automatic_attribute_whitelist default_attribute_whitelist normal_attribute_whitelist override_attribute_whitelist }.each do |white_list|
                if Chef::Config[:knife][white_list.to_sym] && Chef::Config[:knife][white_list.to_sym].is_a?(Array)
-                 client_rb << [
+                 white_lists.push([
                    white_list,
                    Chef::Config[:knife][white_list.to_sym].to_s
-                 ].join(" ")
+                 ].join(" "))
                end
              end
-             client_rb
+             client_rb << white_lists.join("\n")
            end
 
            alias :orig_start_chef start_chef


### PR DESCRIPTION
I added options of whitelist in knife.rb.

```
knife[:default_attribute_whitelist] = ["some_attribute1", "some_attribute2", ...]
knife[:automatic_attribute_whitelist] = ["some_attribute3", "some_attribute4", ...]
```

And I executeed knife zero bootstrap.
An error occured like below.

```
$ bundle ex knife zero bootstrap xxx.xxx.xxx.xxx -x root --ssh-password ********
Doing old-style registration with the validation key at ...
Delete your validation key in order to use your user credentials instead

Connecting to xxx.xxx.xxx.xxx
xxx.xxx.xxx.xxx -----> Existing Chef installation detected
xxx.xxx.xxx.xxx Starting first Chef Client run...
xxx.xxx.xxx.xxx [2015-09-25T17:18:01+09:00] FATAL: Configuration error SyntaxError: /etc/chef/client.rb:5: syntax error, unexpected tIDENTIFIER, expecting end-of-input
xxx.xxx.xxx.xxx ...s/"]default_attribute_whitelist ["hostname"]
xxx.xxx.xxx.xxx ...                               ^
xxx.xxx.xxx.xxx [2015-09-25T17:18:01+09:00] FATAL: Aborting due to error in '/etc/chef/client.rb'
```

client.rb in the node server is below.

```
...

automatic_attribute_whitelist ["some_attribute3", "some_attribute4", ...]default_attribute_whitelist ["some_attribute1", "some_attribute2", ...]

```

Line breaks aren't included in description of whitelists.
I modified codes that we can add options of multi-type whitelists.

Best regards.
