### PR TITLE
include net-ssh-multi patch #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v1.9.2
+
+- Monkey: include Fixed host parsing to work with ipv6 addresses net-ssh/net-ssh-multi#9
+    - https://github.com/net-ssh/net-ssh-multi/pull/9
+
 ## v1.9.1
 
 - Compatibility: Keep same behavior of --json-attribute-file option.

--- a/lib/knife-zero/net-ssh-multi-patch.rb
+++ b/lib/knife-zero/net-ssh-multi-patch.rb
@@ -28,4 +28,30 @@ if Net::SSH::Multi::Version::STRING == "1.1.0" || Net::SSH::Multi::Version::STRI
       end
     end
   end
+
+  # https://github.com/net-ssh/net-ssh-multi/pull/9
+  require 'net/ssh/multi/server'
+  module Net::SSH::Multi
+    class Server
+      class_eval do
+        def initialize(master, host, options={})
+          @master = master
+          @options = options.dup
+
+          ## Patched line here
+          @user, @host, port = host.match(/^(?:([^;,:=]+)@|)\[?(.*?)\]?(?::(\d+)|)$/)[1,3]
+
+          user_opt, port_opt = @options.delete(:user), @options.delete(:port)
+
+          @user = @user || user_opt || master.default_user
+          port ||= port_opt
+
+          @options[:port] = port.to_i if port
+
+          @gateway = @options.delete(:via)
+          @failed = false
+        end
+      end
+    end
+  end
 end

--- a/lib/knife-zero/version.rb
+++ b/lib/knife-zero/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Zero
-    VERSION = "1.9.1"
+    VERSION = "1.9.2.dev"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end

--- a/test/knife-zero/test_versioin.rb
+++ b/test/knife-zero/test_versioin.rb
@@ -2,6 +2,6 @@ require "knife-zero/version"
 
 class TC_Version < Test::Unit::TestCase
   test "returns version correctly" do
-    assert_equal("1.9.1", Knife::Zero::VERSION)
+    assert_equal("1.9.2.dev", Knife::Zero::VERSION)
   end
 end


### PR DESCRIPTION
net-ssh-multiのipv6対応PRをモンキーパッチで取り込み。