### PR TITLE
add new option appendix_config to zero bootstrap

### DIFF
--- a/lib/chef/knife/zero_bootstrap.rb
+++ b/lib/chef/knife/zero_bootstrap.rb
@@ -34,7 +34,7 @@ class Chef
 
       option :appendix_config,
         :long => "--appendix-config PATH",
-        :description => "",
+        :description => "Append lines to end of client.rb on remote node from file.",
         :proc => lambda { |o| File.read(o) },
         :default => nil
 

--- a/lib/chef/knife/zero_bootstrap.rb
+++ b/lib/chef/knife/zero_bootstrap.rb
@@ -32,6 +32,12 @@ class Chef
         :default => true,
         :proc => lambda { |v| Chef::Config[:knife][:bootstrap_converge] = v }
 
+      option :appendix_config,
+        :long => "--appendix-config PATH",
+        :description => "",
+        :proc => lambda { |o| File.read(o) },
+        :default => nil
+
       ## For support policy_document_databag(old style)
       self.options[:policy_name][:description] = "Policy name to use (It'll be set as deployment_group=POLICY_NAME-local)"
 

--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -37,6 +37,10 @@ class Chef
                               %Q{deployment_group "#{@config[:policy_name]}-local"}].join("\n")
              end
 
+             if @config[:appendix_config]
+               client_rb << ["\n## --appendix-config", @config[:appendix_config]].join("\n")
+             end
+
              client_rb
            end
 


### PR DESCRIPTION
`--appendix-config PATH       Append lines to end of client.rb on remote node from file.`

Usage:

```
$ echo "# bar" > foo 
$ knife zero bootstrap .... --appendix-config foo
```

```
## /etc/chef/client.rb on remote node.

(configurations)
## --appendix-config
# bar
```

Little related: #39 