### PR TITLE
apply no-color to remote side

### DIFF
--- a/lib/chef/knife/zero_apply.rb
+++ b/lib/chef/knife/zero_apply.rb
@@ -57,6 +57,7 @@ class Chef
         s << " -s"
         s << " --minimal-ohai" if @config[:minimal_ohai]
         s << " -j #{@config[:json_attribs]}" if @config[:json_attribs]
+        s << " --no-color" unless @config[:color]
         s << " -W" if @config[:why_run]
         Chef::Log.info "Remote command: " + s
         s

--- a/lib/chef/knife/zero_converge.rb
+++ b/lib/chef/knife/zero_converge.rb
@@ -91,6 +91,7 @@ class Chef
         s << " --splay #{@config[:splay]}" if @config[:splay]
         s << " -n #{@config[:named_run_list]}" if @config[:named_run_list]
         s << " --skip-cookbook-sync" if @config[:skip_cookbook_sync]
+        s << " --no-color" unless @config[:color]
         s << " -W" if @config[:why_run]
         Chef::Log.info "Remote command: " + s
         s


### PR DESCRIPTION
Current `--no-color` works for only knife zero side. I'd like to apply no-color option to client side.