### PR TITLE
add new option `--chef-license` to converge

### DIFF
--- a/lib/chef/knife/zero_converge.rb
+++ b/lib/chef/knife/zero_converge.rb
@@ -73,6 +73,12 @@ class Chef
                end
              }
 
+      # import from LicenseAcceptance:CLIFlags:MixlibCLI
+      option :chef_license,
+             long: '--chef-license ACCEPTANCE',
+             description: %{Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')},
+             required: false
+
       # Common connectivity options for compatibility
       option :connection_user,
              short: '-U USERNAME',
@@ -121,6 +127,7 @@ class Chef
         s << ' --skip-cookbook-sync' if @config[:skip_cookbook_sync]
         s << ' --no-color' unless @config[:color]
         s << " -E #{@config[:environment]}" if @config[:environment]
+        s << " --chef-license #{@config[:chef_license]}" if @config[:chef_license]
         s << ' -W' if @config[:why_run]
         Chef::Log.info 'Remote command: ' + s
         s

--- a/lib/knife-zero/version.rb
+++ b/lib/knife-zero/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Zero
-    VERSION = '2.0.0'.freeze
+    VERSION = '2.0.1.dev'.freeze
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end

--- a/test/knife-zero/test_version.rb
+++ b/test/knife-zero/test_version.rb
@@ -2,6 +2,6 @@ require 'knife-zero/version'
 
 class TC_Version < Test::Unit::TestCase
   test 'returns version correctly' do
-    assert_equal('2.0.0', Knife::Zero::VERSION)
+    assert_equal('2.0.1.dev', Knife::Zero::VERSION)
   end
 end


### PR DESCRIPTION
after upgrade to 15.x on remote-node. it asks acceptance at first run.

```
+---------------------------------------------+
            Chef License Acceptance

Before you can continue, 2 product licenses
must be accepted. View the license at
https://www.chef.io/end-user-license-agreement/

Licenses that need accepting:
  * Chef Infra Client
  * Chef InSpec

Do you accept the 2 product licenses (yes/no)?
```
