### PR TITLE
Properly quoted policy name

### DIFF
--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -34,8 +34,8 @@ class Chef
               client_rb << ["\n", 'use_policyfile true',
                             'versioned_cookbooks true',
                             'policy_document_native_api true',
-                            "policy_name '#{@config[:policy_name]}'",
-                            "policy_group '#{@config[:policy_group]}'"].join("\n")
+                            "policy_name \"#{@config[:policy_name]}]\"",
+                            "policy_group \"#{@config[:policy_group]}\""].join("\n")
             end
 
             if @config[:appendix_config]


### PR DESCRIPTION
# What does this do?

This PR fixes improperly quoted policy name, which forbids usage of `policy-name`, `policy.name` and so on.

# Wait a sec, didn't we fix that a year and a half ago in #117?

Not really. The policy name was quoted with single quotes, and here's the bootstrap script:

```
sh -c '
...
use_policyfile true
versioned_cookbooks true
policy_document_native_api true
policy_name 'ayte-space-dedicated-warehouse'
policy_group 'local'
EOP
```
As you see, the script itself is quoted in single quotes, so it just concatenated values between quotes with the rest of script, effectively deleting single quotes. Ouchie.