### PR TITLE
Check knife version instead of chef version before overriding knife method

### DIFF
--- a/lib/knife-zero/bootstrap_ssh.rb
+++ b/lib/knife-zero/bootstrap_ssh.rb
@@ -1,5 +1,5 @@
 require 'chef/knife/ssh'
-require 'chef/version'
+require 'chef/knife/version'
 
 class Chef
   class Knife
@@ -10,7 +10,7 @@ class Chef
         require 'knife-zero/helper'
       end
 
-    if Gem::Version.new(Chef::VERSION) < Gem::Version.new("17.3.27")
+    if Gem::Version.new(Chef::Knife::VERSION) < Gem::Version.new("17.3.27")
       def ssh_command(command, subsession = nil) # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/CyclomaticComplexity
         if config[:client_version]
           case config[:alter_project]


### PR DESCRIPTION
Now that `knife` is a separate gem as of v17 and the dependencies between `chef` and `knife` seem pretty relaxed, you could end up using a newer `knife` version with an older `chef` version. If you happen to use something like `chef` v17.2 and knife v17.3, by looking at the `chef` version, we'd end up patching the old `ssh_command` method but then calling `super` to the newer `knife` `ssh_command` method. This could lead to a `NoMethodError` as the newer `knife` `ssh_command` tried to call `session_list.close` in it's `ensure`, however the old patched method had no `session_list` variable.

If we're patching a `knife` method, seems more appropriate to check the `knife` version.