### PR TITLE
Bootstrap: Allow overriding node name for the new node

### DIFF
--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -60,6 +60,7 @@ class Chef
                 s << " -S http://127.0.0.1:#{::Knife::Zero::Helper.zero_remote_port}"
                 s << " -K #{[::File.dirname(@config[:node_config_file]), 'validation.pem'].join('/')}"
                 s << ' -W' if @config[:why_run]
+                s << " -N #{@config[:chef_node_name]}" if @config[:chef_node_name]
                 Chef::Log.info 'Remote command: ' + s
                 s
               else


### PR DESCRIPTION
Enable use of **-N, --node-name** option, on bootstrap.