### PR TITLE
Bootstrap: Include blocked attribute lists in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-none.
+- Bootstrap: Include blocked attribute lists in config [#171](https://github.com/higanworks/knife-zero/pull/171) HT [@cgunther](https://github.com/cgunther)
 
 ## v2.5.2
 

--- a/lib/knife-zero/core/bootstrap_context.rb
+++ b/lib/knife-zero/core/bootstrap_context.rb
@@ -18,19 +18,21 @@ class Chef
           alias_method :orig_config_content, :config_content
           def config_content # rubocop:disable Metrics/AbcSize
             client_rb = orig_config_content
-            allowed_lists = []
+            attribute_lists = []
             %w{
               automatic_attribute_whitelist default_attribute_whitelist normal_attribute_whitelist override_attribute_whitelist
               allowed_automatic_attributes allowed_default_attributes allowed_normal_attributes allowed_override_attributes
-            }.each do |allowed_list|
-              next unless Chef::Config[:knife][allowed_list.to_sym]&.is_a?(Array)
+              automatic_attribute_blacklist default_attribute_blacklist normal_attribute_blacklist override_attribute_blacklist
+              blocked_automatic_attributes blocked_default_attributes blocked_normal_attributes blocked_override_attributes
+            }.each do |attribute_list|
+              next unless Chef::Config[:knife][attribute_list.to_sym]&.is_a?(Array)
 
-              allowed_lists.push([
-                allowed_list,
-                Chef::Config[:knife][allowed_list.to_sym].to_s
+              attribute_lists.push([
+                attribute_list,
+                Chef::Config[:knife][attribute_list.to_sym].to_s
               ].join(' '))
             end
-            client_rb << allowed_lists.join("\n")
+            client_rb << attribute_lists.join("\n")
 
             ## For support policy_document_native_api
             if @config[:policy_name]


### PR DESCRIPTION
Allowed lists are copied from the local knife.rb config to the config dropped on each node during bootstrap, so might as well support the blocked lists as well.

Furthermore, support the legacy blacklist names since the whitelist names are also supported.